### PR TITLE
Add name for linter provider

### DIFF
--- a/lib/schema-linter.ts
+++ b/lib/schema-linter.ts
@@ -89,6 +89,7 @@ var makeValidator = _.memoize(schema => {
 
 export var provider = [
     {
+        name: 'json-schema',
         grammarScopes: ['source.json'],
         scope: 'file',
         lintOnFly: true,


### PR DESCRIPTION
Define a name of 'json-schema' for the Linter provider so messages from it can be identified.

Note that the fact that this was giving an error was a bug in Linter (https://github.com/steelbrain/linter/pull/1371), but having it defined is a requirement for Linter v2, and is nice for the user anyway :wink:.

Fixes #33.